### PR TITLE
Don't return HadoopNamespaces on /vXxxx

### DIFF
--- a/lib/hadoop-stats.js
+++ b/lib/hadoop-stats.js
@@ -57,7 +57,7 @@ function HadoopStatsServer(options)
         else
         {
             var pathname = url.parse(req.url, true).pathname;
-            var path2ns = /^\/([^\/]+)?$/;
+            var path2ns = /^\/([^\/]+)$/;
             if ((pathInfo = pathname.match(path2ns)))
             {
                 var key = '@' + pathInfo[1];
@@ -66,10 +66,10 @@ function HadoopStatsServer(options)
                 {
                     res.write(JSON.stringify(data));
                 }
-                else
-                {
-                    res.write(JSON.stringify(options.audience.getHadoopNamespaces()));
-                }
+            }
+            else
+            {
+                res.write(JSON.stringify(options.audience.getHadoopNamespaces()));
             }
         }
         res.end();


### PR DESCRIPTION
Just return an empty result when there are no data in hadoop for an entry. Only return HadoopNamespaces on "/" endpoint (well in fact on every endpoint not matching path2ns)